### PR TITLE
Fix manylinux1 Python 3.3 and 3.4 builds and add Travis testing.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,35 @@
-language: generic
+language: python
+
+os:
+  - linux
+
+python:
+  - 2.6
+  - 2.7
+  - 3.3
+  - 3.4
+  - 3.5
+  - 3.6
 
 matrix:
   include:
-    - sudo: required
-      services:
-        - docker
-      env: DOCKER_IMAGE=quay.io/pypa/manylinux1_x86_64
-    - sudo: required
-      services:
-        - docker
-      env: DOCKER_IMAGE=quay.io/pypa/manylinux1_i686
-           PRE_CMD=linux32
-
-install:
-  - docker pull $DOCKER_IMAGE
+    # Travis does not support Python versions on OSX:
+    # https://github.com/travis-ci/travis-ci/issues/2312
+    - language: generic
+      os: osx
+      # Set the Python version to display it in the Travis UI.
+      python: 2.7
+    - language: generic
+      os: osx
+      # Set the Python version to display it in the Travis UI.
+      python: 3.6
+      before_install:
+        - if ! command -v python3; then
+            brew update
+            brew install python3
+            virtualenv env -p python3
+            source env/bin/activate
+          fi
 
 script:
-  - docker run --rm -v `pwd`:/io $DOCKER_IMAGE $PRE_CMD /io/build-wheels.sh /io
+  - python setup.py test

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,29 @@ matrix:
             virtualenv env -p python3
             source env/bin/activate
           fi
+    # Test manylinux1 64 and 32 bit wheels.
+    - sudo: required
+      os: linux
+      language: generic
+      services:
+        - docker
+      env: DOCKER_IMAGE=quay.io/pypa/manylinux1_x86_64
+    - sudo: required
+      os: linux
+      language: generic
+      services:
+        - docker
+      env: DOCKER_IMAGE=quay.io/pypa/manylinux1_i686
+           PRE_CMD=linux32
+
+install:
+  - if [ -n "$DOCKER_IMAGE" ]; then
+      docker pull "$DOCKER_IMAGE"
+    fi
 
 script:
-  - python setup.py test
+  - if [ -n "$DOCKER_IMAGE" ]; then
+      docker run --rm -v "$(pwd)":/io "$DOCKER_IMAGE" "$PRE_CMD" /io/build-wheels.sh /io
+    else
+      python setup.py test
+    fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,10 +25,10 @@ matrix:
       python: 3.6
       before_install:
         - if ! command -v python3; then
-            brew update
-            brew install python3
-            virtualenv env -p python3
-            source env/bin/activate
+            brew update;
+            brew install python3;
+            virtualenv env -p python3;
+            source env/bin/activate;
           fi
     # Test manylinux1 64 and 32 bit wheels.
     - sudo: required
@@ -47,12 +47,12 @@ matrix:
 
 install:
   - if [ -n "$DOCKER_IMAGE" ]; then
-      docker pull "$DOCKER_IMAGE"
+      docker pull "$DOCKER_IMAGE";
     fi
 
 script:
   - if [ -n "$DOCKER_IMAGE" ]; then
-      docker run --rm -v "$(pwd)":/io "$DOCKER_IMAGE" "$PRE_CMD" /io/build-wheels.sh /io
+      docker run --rm -v "$(pwd)":/io "$DOCKER_IMAGE" "$PRE_CMD" /io/build-wheels.sh /io;
     else
-      python setup.py test
+      python setup.py test;
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+language: generic
+
+matrix:
+  include:
+    - sudo: required
+      services:
+        - docker
+      env: DOCKER_IMAGE=quay.io/pypa/manylinux1_x86_64
+    - sudo: required
+      services:
+        - docker
+      env: DOCKER_IMAGE=quay.io/pypa/manylinux1_i686
+           PRE_CMD=linux32
+
+install:
+  - docker pull $DOCKER_IMAGE
+
+script:
+  - docker run --rm -v `pwd`:/io $DOCKER_IMAGE $PRE_CMD /io/build-wheels.sh /io

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ install:
 
 script:
   - if [ -n "$DOCKER_IMAGE" ]; then
-      docker run --rm -v "$(pwd)":/io "$DOCKER_IMAGE" "$PRE_CMD" /io/build-wheels.sh /io;
+      docker run --rm -v "$(pwd)":/io "$DOCKER_IMAGE" $PRE_CMD /io/build-wheels.sh /io;
     else
       python setup.py test;
     fi

--- a/build-wheels.sh
+++ b/build-wheels.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+if [ "$#" -ne 1 ]; then
+    echo "$0 requires one argument: <BSONJS_SOURCE_DIRECTORY>"
+    echo "For example: $0 /user/home/git/python-bsonjs"
+    exit 1
+fi
+
+set -e -x
+
+BSONJS_SOURCE_DIRECTORY="$1"
+cd "$BSONJS_SOURCE_DIRECTORY"
+
+ls -la
+
+# Compile wheels
+for PYBIN in /opt/python/*/bin; do
+    "${PYBIN}/python" setup.py bdist_wheel
+    # https://github.com/pypa/manylinux/issues/49
+    rm -rf build
+done
+ 
+# Audit wheels and write multilinux1 tag
+for whl in dist/*.whl; do
+    auditwheel repair "$whl" -w dist
+done
+
+# Install packages and test
+for PYBIN in /opt/python/*/bin; do
+    "${PYBIN}/pip" install python-bsonjs --no-index -f dist
+    # The tests require PyMongo.
+    "${PYBIN}/pip" install 'pymongo>=3.4' unittest2
+    for TEST_FILE in "${BSONJS_SOURCE_DIRECTORY}"/test/test_*.py; do
+        "${PYBIN}/python" "$TEST_FILE" -v
+    done
+done
+
+ls -lah dist

--- a/build-wheels.sh
+++ b/build-wheels.sh
@@ -19,7 +19,7 @@ for PYBIN in /opt/python/*/bin; do
     # https://github.com/pypa/manylinux/issues/49
     rm -rf build
 done
- 
+
 # Audit wheels and write multilinux1 tag
 for whl in dist/*.whl; do
     auditwheel repair "$whl" -w dist

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+if [ "$#" -ne 0 ]; then
+    echo "$0 takes no arguments"
+    exit 1
+fi
+
+set -e -x
+
+docker run --rm -v `pwd`:/io quay.io/pypa/manylinux1_x86_64 /io/build-wheels.sh /io
+docker run --rm -v `pwd`:/io quay.io/pypa/manylinux1_i686 linux32 /io/build-wheels.sh /io

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -7,5 +7,11 @@ fi
 
 set -e -x
 
-docker run --rm -v `pwd`:/io quay.io/pypa/manylinux1_x86_64 /io/build-wheels.sh /io
-docker run --rm -v `pwd`:/io quay.io/pypa/manylinux1_i686 linux32 /io/build-wheels.sh /io
+
+DOCKER_IMAGE=quay.io/pypa/manylinux1_x86_64
+docker pull "$DOCKER_IMAGE"
+docker run --rm -v `pwd`:/io "$DOCKER_IMAGE" /io/build-wheels.sh /io
+
+DOCKER_IMAGE=quay.io/pypa/manylinux1_i686
+docker pull "$DOCKER_IMAGE"
+docker run --rm -v `pwd`:/io "$DOCKER_IMAGE" linux32 /io/build-wheels.sh /io

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,13 @@ if sys.version_info[:2] == (2, 6):
 else:
     test_suite = "test"
 
+libraries = []
+if sys.platform == "win32":
+    libraries.append("ws2_32")
+elif sys.platform != "darwin":
+    # librt may be needed for clock_gettime()
+    libraries.append("rt")
+
 setup(
     name="python-bsonjs",
     version="0.2.0.dev0",
@@ -79,7 +86,7 @@ setup(
                           "libbson/src/jsonsl",
                           "libbson/src/bson"],
             define_macros=[("BSON_COMPILATION", 1)],
-            libraries=["ws2_32"] if sys.platform == "win32" else []
+            libraries=libraries
         )
     ]
 )


### PR DESCRIPTION
bsonjs wheels are broken on Python 3.3 and 3.4:
```
[root@71f47a1ffa63 /]# uname -a
Linux 71f47a1ffa63 4.9.21-moby #1 SMP Wed Apr 12 01:18:47 UTC 2017 x86_64 x86_64 x86_64 GNU/Linux
[root@71f47a1ffa63 /]# /opt/python/cp34-cp34m/bin/python -m pip install python-bsonjs
Collecting python-bsonjs
  Downloading python_bsonjs-0.1.1-cp34-cp34m-manylinux1_x86_64.whl (256kB)
    100% |████████████████████████████████| 266kB 3.5MB/s
Installing collected packages: python-bsonjs
Successfully installed python-bsonjs-0.1.1
[root@71f47a1ffa63 /]# /opt/python/cp34-cp34m/bin/python
Python 3.4.6 (default, Apr 18 2017, 15:35:22)
[GCC 4.8.2 20140120 (Red Hat 4.8.2-15)] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import bsonjs
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ImportError: /opt/python/cp34-cp34m/lib/python3.4/site-packages/bsonjs.cpython-34m.so: undefined symbol: clock_gettime
```

The fix is to link to librt on Linux. 

This change also adds Travis testing on linux/osx plus manylinux1 wheels.