### PR TITLE
Fix test_binary test failure

### DIFF
--- a/test/test_bsonjs.py
+++ b/test/test_bsonjs.py
@@ -182,7 +182,13 @@ class TestBsonjs(unittest.TestCase):
                          uuid.UUID("f47ac10b-58cc-4372-a567-0e02b2c3d479")})
 
     def test_binary(self):
-        bin_type_dict = {"bin": Binary(b"\x00\x01\x02\x03\x04")}
+        # PyMongo loads $binary subtype 0 as bytes in Python 3.
+        if sys.version_info[0] == 2:
+            bin0 = Binary(b"\x00\x01\x02\x03\x04")
+        else:
+            bin0 = b"\x00\x01\x02\x03\x04"
+
+        bin_type_dict = {"bin": bin0}
         md5_type_dict = {
             "md5": Binary(b" n7\x18\xaf\t/\xd1\xd1/\x80\xca\xe7q\xcc\xac",
                           MD5_SUBTYPE)


### PR DESCRIPTION
PyMongo loads $binary subtype 0 as bytes in Python 3.

Fixes https://github.com/mongodb-labs/python-bsonjs/issues/21:
```
FAIL: test_binary (test.test_bsonjs.TestBsonjs)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/julius/python-bsonjs/test/test_bsonjs.py", line 195, in test_binary
    self.round_trip(bin_type_dict)
  File "/Users/julius/python-bsonjs/test/test_bsonjs.py", line 79, in round_trip
    self.assertEqual(doc, json_util.loads(
AssertionError: {'bin': Binary(b'\x00\x01\x02\x03\x04', 0)} != {'bin': b'\x00\x01\x02\x03\x04'}
- {'bin': Binary(b'\x00\x01\x02\x03\x04', 0)}
?         -------                       ----
+ {'bin': b'\x00\x01\x02\x03\x04'}
```