### PR TITLE
Use the Python 3.6+ limited API

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+py-limited-api = cp36

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,9 @@ setup(
                           "src/bson",
                           "src/jsonsl",
                           "src/common"],
-            define_macros=[("BSON_COMPILATION", 1)],
+            py_limited_api=True,
+            define_macros=[("BSON_COMPILATION", 1),
+                           ("Py_LIMITED_API", "0x03060000")],
             libraries=libraries
         )
     ]

--- a/src/bsonjs.c
+++ b/src/bsonjs.c
@@ -71,9 +71,10 @@ _dumps(PyObject *bson, int mode)
     Py_ssize_t bson_len;
     size_t json_len;
 
-    bson_str = PyBytes_AS_STRING(bson);
-    bson_len = PyBytes_GET_SIZE(bson);
-
+    if (PyBytes_AsStringAndSize(bson, &bson_str, &bson_len) == -1) {
+        // error is already set
+        return NULL;
+    }
     json = bson_str_to_json(bson_str, (size_t)bson_len, &json_len, mode);
     if (!json) {
         // error is already set


### PR DESCRIPTION
This changes us to use the stable C API (limited API): https://docs.python.org/3/c-api/stable.html 

What this means is that we only need to build wheels for Python 3.6 and they will work for all future python versions. For example the manylinux wheels are now just:
```
python_bsonjs-0.3.0.dev0-cp36-abi3-manylinux_2_5_i686.manylinux1_i686.whl
python_bsonjs-0.3.0.dev0-cp36-abi3-manylinux_2_5_x86_64.manylinux1_x86_64.whl
```
Mac is now just:
```
python_bsonjs-0.3.0.dev0-cp36-abi3-macosx_10_9_x86_64.whl
python_bsonjs-0.3.0.dev0-cp36-abi3-macosx_10_9_universal2.whl  # The universal2 tag is new with Python 3.10
```
And similar with windows.