### PR TITLE
Fix PyMethodDef warnings resolve #42

### DIFF
--- a/src/bsonjs.c
+++ b/src/bsonjs.c
@@ -231,8 +231,8 @@ loads(PyObject *self, PyObject *args)
 }
 
 static PyMethodDef BsonjsClientMethods[] = {
-    {"dump", dump, METH_VARARGS | METH_KEYWORDS, dump__doc__},
-    {"dumps", dumps, METH_VARARGS | METH_KEYWORDS, dumps__doc__},
+    {"dump", (PyCFunction)(void(*)(void))dump, METH_VARARGS | METH_KEYWORDS, dump__doc__},
+    {"dumps", (PyCFunction)(void(*)(void))dumps, METH_VARARGS | METH_KEYWORDS, dumps__doc__},
     {"load", load, METH_VARARGS, load__doc__},
     {"loads", loads, METH_VARARGS, loads__doc__},
     {NULL, NULL, 0, NULL}


### PR DESCRIPTION
Resolves https://github.com/mongodb-labs/python-bsonjs/issues/42

See https://docs.python.org/3/extending/extending.html?highlight=meth_varargs%20meth_keywords#keyword-parameters-for-extension-functions:
```c
static PyMethodDef keywdarg_methods[] = {
    /* The cast of the function is necessary since PyCFunction values
     * only take two PyObject* parameters, and keywdarg_parrot() takes
     * three.
     */
    {"parrot", (PyCFunction)(void(*)(void))keywdarg_parrot, METH_VARARGS | METH_KEYWORDS,
     "Print a lovely skit to standard output."},
    {NULL, NULL, 0, NULL}   /* sentinel */
};
```