### PR TITLE
Fix check-manifest warnings

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,10 @@
 include README.rst
+include CHANGELOG.rst
 include LICENSE
-include ez_setup.py
-recursive-include libbson *.h
+recursive-include src LICENSE
 recursive-include src *.h
 recursive-include test *.py
+exclude benchmark.py
+exclude build-wheels.sh
+exclude docker-build.sh
+exclude vendor.sh


### PR DESCRIPTION
Fix these warnings:
```
$ check-manifest                             
lists of files in version control and sdist do not match!
missing from sdist:
  CHANGELOG.rst
  benchmark.py
  build-wheels.sh
  docker-build.sh
  src/jsonsl/LICENSE
  vendor.sh
suggested MANIFEST.in rules:
  include *.py
  include *.rst
  include *.sh
```