### PR TITLE
INTPYTHON-1029: Improve the runtime performance of the bsonjs.dumps API

### DIFF
--- a/bsonjs/bson/bson-iso8601.c
+++ b/bsonjs/bson/bson-iso8601.c
@@ -287,6 +287,7 @@ _bson_iso8601_date_format (int64_t msec_since_epoch, bson_string_t *str)
    time_t t;
    int64_t msecs_part;
    char buf[64];
+   uint32_t len;
 
    msecs_part = msec_since_epoch % 1000;
    t = (time_t) (msec_since_epoch / 1000);
@@ -295,23 +296,23 @@ _bson_iso8601_date_format (int64_t msec_since_epoch, bson_string_t *str)
    {
       struct tm posix_date;
       gmtime_r (&t, &posix_date);
-      strftime (buf, sizeof buf, "%Y-%m-%dT%H:%M:%S", &posix_date);
+      len = strftime (buf, sizeof buf, "%Y-%m-%dT%H:%M:%S", &posix_date);
    }
 #elif defined(_MSC_VER)
    {
       /* Windows gmtime_s is thread-safe */
       struct tm time_buf;
       gmtime_s (&time_buf, &t);
-      strftime (buf, sizeof buf, "%Y-%m-%dT%H:%M:%S", &time_buf);
+      len = strftime (buf, sizeof buf, "%Y-%m-%dT%H:%M:%S", &time_buf);
    }
 #else
-   strftime (buf, sizeof buf, "%Y-%m-%dT%H:%M:%S", gmtime (&t));
+   len = strftime (buf, sizeof buf, "%Y-%m-%dT%H:%M:%S", gmtime (&t));
 #endif
 
    if (msecs_part) {
       bson_string_append_printf (str, "%s.%03" PRId64 "Z", buf, msecs_part);
    } else {
-      bson_string_append (str, buf);
+      bson_string_append (str, buf, len);
       bson_string_append_c (str, 'Z');
    }
 }

--- a/bsonjs/bson/bson-iter.c
+++ b/bsonjs/bson/bson-iter.c
@@ -1899,18 +1899,20 @@ bson_iter_visit_all (bson_iter_t *iter,             /* INOUT */
 {
    uint32_t bson_type = 0;
    const char *key = NULL;
+   uint32_t key_len;
    bool unsupported;
 
    BSON_ASSERT (iter);
    BSON_ASSERT (visitor);
 
    while (_bson_iter_next_internal (iter, 0, &key, &bson_type, &unsupported)) {
-      if (*key && !bson_utf8_validate (key, strlen (key), false)) {
+      key_len = bson_iter_key_len (iter);
+      if (*key && !bson_utf8_validate (key, key_len, false)) {
          iter->err_off = iter->off;
          break;
       }
 
-      if (VISIT_BEFORE (iter, key, data)) {
+      if (VISIT_BEFORE (iter, key, key_len, data)) {
          return true;
       }
 

--- a/bsonjs/bson/bson-string.c
+++ b/bsonjs/bson/bson-string.c
@@ -34,6 +34,69 @@
 /*
  *--------------------------------------------------------------------------
  *
+ * bson_string_new_n --
+ *
+ *       Create a new bson_string_t.
+ *
+ *       bson_string_t is a power-of-2 allocation growing string. Every
+ *       time data is appended the next power of two size is chosen for
+ *       the allocation. Pretty standard stuff.
+ *
+ *       It is UTF-8 aware through the use of bson_string_append_unichar().
+ *       The proper UTF-8 character sequence will be used.
+ *
+ * Parameters:
+ *       @str: a string to copy or NULL.
+ *       @len: number of characters to copy from str.
+ *
+ * Returns:
+ *       A newly allocated bson_string_t that should be freed with
+ *       bson_string_free().
+ *
+ * Side effects:
+ *       None.
+ *
+ *--------------------------------------------------------------------------
+ */
+
+bson_string_t *
+bson_string_new_n (const char *str, uint32_t len) /* IN */
+{
+   bson_string_t *ret;
+   size_t len_sz;
+
+   ret = bson_malloc0 (sizeof *ret);
+   if (str) {
+      BSON_ASSERT (len <= UINT32_MAX);
+      ret->len = len;
+   } else {
+      ret->len = 0;
+   }
+   ret->alloc = ret->len + 1;
+
+   if (!bson_is_power_of_two (ret->alloc)) {
+      len_sz = bson_next_power_of_two ((size_t) ret->alloc);
+      BSON_ASSERT (len_sz <= UINT32_MAX);
+      ret->alloc = (uint32_t) len_sz;
+   }
+
+   BSON_ASSERT (ret->alloc >= ret->len + 1);
+
+   ret->str = bson_malloc (ret->alloc);
+
+   if (str) {
+      memcpy (ret->str, str, ret->len);
+   }
+
+   ret->str[ret->len] = '\0';
+
+   return ret;
+}
+
+
+/*
+ *--------------------------------------------------------------------------
+ *
  * bson_string_new --
  *
  *       Create a new bson_string_t.
@@ -61,36 +124,7 @@
 bson_string_t *
 bson_string_new (const char *str) /* IN */
 {
-   bson_string_t *ret;
-   size_t len_sz;
-
-   ret = bson_malloc0 (sizeof *ret);
-   if (str) {
-      len_sz = strlen (str);
-      BSON_ASSERT (len_sz <= UINT32_MAX);
-      ret->len = (uint32_t) len_sz;
-   } else {
-      ret->len = 0;
-   }
-   ret->alloc = ret->len + 1;
-
-   if (!bson_is_power_of_two (ret->alloc)) {
-      len_sz = bson_next_power_of_two ((size_t) ret->alloc);
-      BSON_ASSERT (len_sz <= UINT32_MAX);
-      ret->alloc = (uint32_t) len_sz;
-   }
-
-   BSON_ASSERT (ret->alloc >= ret->len + 1);
-
-   ret->str = bson_malloc (ret->alloc);
-
-   if (str) {
-      memcpy (ret->str, str, ret->len);
-   }
-
-   ret->str[ret->len] = '\0';
-
-   return ret;
+   return bson_string_new_n(str, str ? strlen(str) : 0);
 }
 
 char *
@@ -120,7 +154,8 @@ bson_string_free (bson_string_t *string, /* IN */
  *
  * bson_string_append --
  *
- *       Append the UTF-8 string @str to @string.
+ *       Append the UTF-8 string @str of length @len to @string.
+ *       The calling function is responsible for ensuring that @len is the actual length (i.e. strlen) of @str.
  *
  * Returns:
  *       None.
@@ -133,17 +168,16 @@ bson_string_free (bson_string_t *string, /* IN */
 
 void
 bson_string_append (bson_string_t *string, /* IN */
-                    const char *str)       /* IN */
+                    const char *str, /* IN */
+                    uint32_t len) /* IN */
 {
-   uint32_t len;
    size_t len_sz;
 
    BSON_ASSERT (string);
    BSON_ASSERT (str);
 
-   len_sz = strlen (str);
-   BSON_ASSERT (bson_in_range_unsigned (uint32_t, len_sz));
-   len = (uint32_t) len_sz;
+   BSON_ASSERT (bson_in_range_unsigned (uint32_t, len));
+
 
    if ((string->alloc - string->len - 1) < len) {
       BSON_ASSERT (string->alloc <= UINT32_MAX - len);
@@ -193,7 +227,7 @@ bson_string_append_c (bson_string_t *string, /* IN */
    if (BSON_UNLIKELY (string->alloc == (string->len + 1))) {
       cc[0] = c;
       cc[1] = '\0';
-      bson_string_append (string, cc);
+      bson_string_append (string, cc, 1);
       return;
    }
 
@@ -232,7 +266,7 @@ bson_string_append_unichar (bson_string_t *string,  /* IN */
 
    if (len <= 6) {
       str[len] = '\0';
-      bson_string_append (string, str);
+      bson_string_append (string, str, len);
    }
 }
 
@@ -258,14 +292,26 @@ bson_string_append_printf (bson_string_t *string, const char *format, ...)
 {
    va_list args;
    char *ret;
+   char buf[256];
+   int n;
 
    BSON_ASSERT (string);
    BSON_ASSERT (format);
 
+   /* Try to format the string on stack which is faster than using malloc for small strings */
    va_start (args, format);
-   ret = bson_strdupv_printf (format, args);
+   n = bson_vsnprintf (buf, sizeof(buf), format, args);
    va_end (args);
-   bson_string_append (string, ret);
+   if (n > -1 && n < (int)sizeof(buf)) {
+      bson_string_append (string, buf, n);
+      return;
+   }
+
+   /* Format the string on heap which is slower but necessary for large strings */
+   va_start (args, format);
+   ret = bson_strdupv_printf (format, (n > -1) ? n + 1 : (int)sizeof(buf) * 2, &n, args);
+   va_end (args);
+   bson_string_append (string, ret, n);
    bson_free (ret);
 }
 
@@ -366,21 +412,24 @@ bson_strdup (const char *str) /* IN */
  *       A newly allocated string that should be freed with bson_free().
  *
  * Side effects:
- *       None.
+ *       @actual_len is set.
  *
  *--------------------------------------------------------------------------
  */
 
 char *
 bson_strdupv_printf (const char *format, /* IN */
+                     int expected_len,   /* IN */
+                     int *actual_len,    /* OUT */
                      va_list args)       /* IN */
 {
    va_list my_args;
    char *buf;
-   int len = 32;
+   int len = expected_len;
    int n;
 
    BSON_ASSERT (format);
+   BSON_ASSERT (actual_len);
 
    buf = bson_malloc0 (len);
 
@@ -390,6 +439,7 @@ bson_strdupv_printf (const char *format, /* IN */
       va_end (my_args);
 
       if (n > -1 && n < len) {
+         *actual_len = n;
          return buf;
       }
 
@@ -427,11 +477,12 @@ bson_strdup_printf (const char *format, /* IN */
 {
    va_list args;
    char *ret;
+   int ret_len;
 
    BSON_ASSERT (format);
 
    va_start (args, format);
-   ret = bson_strdupv_printf (format, args);
+   ret = bson_strdupv_printf (format, 32, &ret_len, args);
    va_end (args);
 
    return ret;

--- a/bsonjs/bson/bson-string.h
+++ b/bsonjs/bson/bson-string.h
@@ -27,6 +27,12 @@
 #include <bson/bson-types.h>
 
 
+/* Expands a string literal at compile time to: "text", (sizeof("text") - 1).
+ * Useful when passing a string literal at compile time to bson_string_append
+ * and bson_string_new_n functions.
+*/
+#define STR_AND_LEN(s) (s), (sizeof(s) - 1)
+
 BSON_BEGIN_DECLS
 
 
@@ -39,10 +45,12 @@ typedef struct {
 
 BSON_EXPORT (bson_string_t *)
 bson_string_new (const char *str);
+BSON_EXPORT (bson_string_t *)
+bson_string_new_n (const char *str, uint32_t len);
 BSON_EXPORT (char *)
 bson_string_free (bson_string_t *string, bool free_segment);
 BSON_EXPORT (void)
-bson_string_append (bson_string_t *string, const char *str);
+bson_string_append (bson_string_t *string, const char *str, uint32_t len);
 BSON_EXPORT (void)
 bson_string_append_c (bson_string_t *string, char str);
 BSON_EXPORT (void)
@@ -56,7 +64,7 @@ bson_strdup (const char *str);
 BSON_EXPORT (char *)
 bson_strdup_printf (const char *format, ...) BSON_GNUC_PRINTF (1, 2);
 BSON_EXPORT (char *)
-bson_strdupv_printf (const char *format, va_list args) BSON_GNUC_PRINTF (1, 0);
+bson_strdupv_printf (const char *format, int expected_len, int *actual_len, va_list args) BSON_GNUC_PRINTF (1, 0);
 BSON_EXPORT (char *)
 bson_strndup (const char *str, size_t n_bytes);
 BSON_EXPORT (void)

--- a/bsonjs/bson/bson-types.h
+++ b/bsonjs/bson/bson-types.h
@@ -411,7 +411,7 @@ typedef struct {
 BSON_ALIGNED_BEGIN (8)
 typedef struct {
    /* run before / after descending into a document */
-   bool (*visit_before) (const bson_iter_t *iter, const char *key, void *data);
+   bool (*visit_before) (const bson_iter_t *iter, const char *key, uint32_t key_len, void *data);
    bool (*visit_after) (const bson_iter_t *iter, const char *key, void *data);
    /* corrupt BSON, or unsupported type and visit_unsupported_type not set */
    void (*visit_corrupt) (const bson_iter_t *iter, void *data);

--- a/bsonjs/bson/bson-utf8.c
+++ b/bsonjs/bson/bson-utf8.c
@@ -80,6 +80,43 @@ _bson_utf8_get_sequence (const char *utf8,    /* IN */
    *first_mask = m;
 }
 
+/*
+ *--------------------------------------------------------------------------
+ *
+ * bson_utf8_get_char --
+ *
+ *       Fetches the next UTF-8 character from the UTF-8 sequence.
+ *
+ * Parameters:
+ *       @utf8: A string containing validated UTF-8.
+ *       @num: The sequence length
+ *       @mask: Mask for the first character
+ *
+ * Returns:
+ *       A 32-bit bson_unichar_t reprsenting the multi-byte sequence.
+ *
+ * Side effects:
+ *       None.
+ *
+ *--------------------------------------------------------------------------
+ */
+
+static bson_unichar_t
+_bson_utf8_get_char (const char *utf8, uint8_t num, uint8_t mask) /* IN */
+{
+   bson_unichar_t c;
+   int i;
+
+   BSON_ASSERT (utf8);
+
+   c = (*utf8) & mask;
+
+   for (i = 1; i < num; i++) {
+      c = (c << 6) | (utf8[i] & 0x3F);
+   }
+
+   return c;
+}
 
 /*
  *--------------------------------------------------------------------------
@@ -123,6 +160,13 @@ bson_utf8_validate (const char *utf8, /* IN */
 
    BSON_ASSERT (utf8);
 
+   /*
+      * Check for NULL bytes.
+    */
+   if (!allow_null && memchr (utf8, '\0', utf8_len)) {
+      return false;
+   }
+
    for (i = 0; i < utf8_len; i += seq_length) {
       _bson_utf8_get_sequence (&utf8[i], &seq_length, &first_mask);
 
@@ -153,22 +197,6 @@ bson_utf8_validate (const char *utf8, /* IN */
          c = (c << 6) | (utf8[j] & 0x3F);
          if ((utf8[j] & 0xC0) != 0x80) {
             return false;
-         }
-      }
-
-      /*
-       * Check for NULL bytes afterwards.
-       *
-       * Hint: if you want to optimize this function, starting here to do
-       * this in the same pass as the data above would probably be a good
-       * idea. You would add a branch into the inner loop, but save possibly
-       * on cache-line bouncing on larger strings. Just a thought.
-       */
-      if (!allow_null) {
-         for (j = 0; j < seq_length; j++) {
-            if (((i + j) > utf8_len) || !utf8[i + j]) {
-               return false;
-            }
          }
       }
 
@@ -236,7 +264,8 @@ bson_utf8_validate (const char *utf8, /* IN */
  *
  * bson_utf8_escape_for_json --
  *
- *       Allocates a new string matching @utf8 except that special
+ *       Return the original string if it is already UTF-8 and no escaping is required.
+ *       Otherwise, allocates a new string matching @utf8 except that special
  *       characters in JSON will be escaped. The resulting string is also
  *       UTF-8 encoded.
  *
@@ -247,28 +276,35 @@ bson_utf8_validate (const char *utf8, /* IN */
  * Parameters:
  *       @utf8: A UTF-8 encoded string.
  *       @utf8_len: The length of @utf8 in bytes or -1 if NUL terminated.
+ *       @escaped_len: Returns the length of the escaped string.
  *
  * Returns:
- *       A newly allocated string that should be freed with bson_free().
+ *       A newly allocated string that should be freed with bson_free() if the original
+ *       string was not UTF-8 or required escaping.
+ *       Otherwise, the original string is returned and should not be freed.
  *
  * Side effects:
- *       None.
+ *       @escaped_len is set.
  *
  *--------------------------------------------------------------------------
  */
 
 char *
 bson_utf8_escape_for_json (const char *utf8, /* IN */
-                           ssize_t utf8_len) /* IN */
+                           ssize_t utf8_len, /* IN*/
+                           uint32_t *escaped_len) /* OUT */
 {
    bson_unichar_t c;
+   uint8_t mask;
+   uint8_t num;
    bson_string_t *str;
    bool length_provided = true;
+   const char* original_utf8 = utf8;
+   const char *first_modified_char = NULL;
    const char *end;
 
    BSON_ASSERT (utf8);
-
-   str = bson_string_new (NULL);
+   BSON_ASSERT (escaped_len);
 
    if (utf8_len < 0) {
       length_provided = false;
@@ -277,29 +313,62 @@ bson_utf8_escape_for_json (const char *utf8, /* IN */
 
    end = utf8 + utf8_len;
 
+   while (utf8 < end && !first_modified_char) {
+      _bson_utf8_get_sequence (utf8, &num, &mask);
+      c = _bson_utf8_get_char (utf8, num, mask);
+      if (c == '\\' || c == '"' || c < ' ' || c >= 0x7F) {
+         first_modified_char = utf8;
+         break;
+      }
+
+      if (c) {
+         utf8+= num;
+      } else {
+         if (length_provided && !*utf8) {
+            /* we escaped nil as '\u0000', now advance past it */
+            utf8++;
+         } else {
+            /* invalid UTF-8 */
+            *escaped_len = 0;
+            return NULL;
+         }
+      }
+   }
+
+   if (!first_modified_char) {
+      /* No escaping required. Return the original input for optimal performance */
+      *escaped_len = (uint32_t)utf8_len;
+      return (char*)original_utf8;
+   }
+
+   /* Escaping is required. copy the first part that does not require escaping and continue to populate it */
+   str = bson_string_new_n (original_utf8, first_modified_char == original_utf8 ? 0 : (first_modified_char - original_utf8) / sizeof(char));
+
    while (utf8 < end) {
-      c = bson_utf8_get_char (utf8);
+      _bson_utf8_get_sequence (utf8, &num, &mask);
+      c = _bson_utf8_get_char (utf8, num, mask);
 
       switch (c) {
       case '\\':
+         bson_string_append (str, STR_AND_LEN("\\\\"));
+         break;
       case '"':
-         bson_string_append_c (str, '\\');
-         bson_string_append_unichar (str, c);
+         bson_string_append (str, STR_AND_LEN("\\\""));
          break;
       case '\b':
-         bson_string_append (str, "\\b");
+         bson_string_append (str, STR_AND_LEN("\\b"));
          break;
       case '\f':
-         bson_string_append (str, "\\f");
+         bson_string_append (str, STR_AND_LEN("\\f"));
          break;
       case '\n':
-         bson_string_append (str, "\\n");
+         bson_string_append (str, STR_AND_LEN("\\n"));
          break;
       case '\r':
-         bson_string_append (str, "\\r");
+         bson_string_append (str, STR_AND_LEN("\\r"));
          break;
       case '\t':
-         bson_string_append (str, "\\t");
+         bson_string_append (str, STR_AND_LEN("\\t"));
          break;
       default:
          if (c < ' ') {
@@ -311,7 +380,7 @@ bson_utf8_escape_for_json (const char *utf8, /* IN */
       }
 
       if (c) {
-         utf8 = bson_utf8_next_char (utf8);
+         utf8+= num;
       } else {
          if (length_provided && !*utf8) {
             /* we escaped nil as '\u0000', now advance past it */
@@ -319,11 +388,13 @@ bson_utf8_escape_for_json (const char *utf8, /* IN */
          } else {
             /* invalid UTF-8 */
             bson_string_free (str, true);
+            *escaped_len = 0;
             return NULL;
          }
       }
    }
 
+   *escaped_len = str->len;
    return bson_string_free (str, false);
 }
 
@@ -353,20 +424,15 @@ bson_utf8_get_char (const char *utf8) /* IN */
    bson_unichar_t c;
    uint8_t mask;
    uint8_t num;
-   int i;
 
    BSON_ASSERT (utf8);
 
    _bson_utf8_get_sequence (utf8, &num, &mask);
-   c = (*utf8) & mask;
 
-   for (i = 1; i < num; i++) {
-      c = (c << 6) | (utf8[i] & 0x3F);
-   }
+   c = _bson_utf8_get_char (utf8, num, mask);
 
    return c;
 }
-
 
 /*
  *--------------------------------------------------------------------------

--- a/bsonjs/bson/bson-utf8.h
+++ b/bsonjs/bson/bson-utf8.h
@@ -31,7 +31,7 @@ BSON_BEGIN_DECLS
 BSON_EXPORT (bool)
 bson_utf8_validate (const char *utf8, size_t utf8_len, bool allow_null);
 BSON_EXPORT (char *)
-bson_utf8_escape_for_json (const char *utf8, ssize_t utf8_len);
+bson_utf8_escape_for_json (const char *utf8, ssize_t utf8_len, uint32_t *escaped_len);
 BSON_EXPORT (bson_unichar_t)
 bson_utf8_get_char (const char *utf8);
 BSON_EXPORT (const char *)

--- a/bsonjs/bson/bson.c
+++ b/bsonjs/bson/bson.c
@@ -62,6 +62,7 @@ typedef struct {
    ssize_t *err_offset;
    uint32_t depth;
    bson_string_t *str;
+   uint32_t start_pos;
    bson_json_mode_t mode;
    int32_t max_len;
    bool max_len_reached;
@@ -83,6 +84,33 @@ _bson_as_json_visit_all (
  * Globals.
  */
 static const uint8_t gZero;
+
+
+/*
+ *--------------------------------------------------------------------------
+ *
+ * _state_str_len --
+ *
+ *       A new state of type bson_json_state_t is created for each new document or array.
+ *       Its str data member is shared among all states for performance reasons (fewer memory allocations and copies).
+ *       This function returns the length of the text that was added to the given state.
+ *
+ * Returns:
+ *       The length of the text that was added to the given state.
+ *
+ * Side effects:
+ *       None.
+ *
+ *--------------------------------------------------------------------------
+ */
+static inline uint32_t
+_state_str_len (bson_json_state_t *state)
+{
+   BSON_ASSERT (state);
+   BSON_ASSERT (bson_cmp_greater_equal_us(state->str->len, state->start_pos));
+   return state->str->len - state->start_pos;
+}
+
 
 /*
  *--------------------------------------------------------------------------
@@ -2316,17 +2344,20 @@ _bson_as_json_visit_utf8 (const bson_iter_t *iter, const char *key, size_t v_utf
 {
    bson_json_state_t *state = data;
    char *escaped;
+   uint32_t escaped_len;
 
    BSON_UNUSED (iter);
    BSON_UNUSED (key);
 
-   escaped = bson_utf8_escape_for_json (v_utf8, v_utf8_len);
+   escaped = bson_utf8_escape_for_json (v_utf8, v_utf8_len, &escaped_len);
 
    if (escaped) {
-      bson_string_append (state->str, "\"");
-      bson_string_append (state->str, escaped);
-      bson_string_append (state->str, "\"");
-      bson_free (escaped);
+      bson_string_append_c (state->str, '\"');
+      bson_string_append (state->str, escaped, escaped_len);
+      bson_string_append_c (state->str, '\"');
+      if (escaped != v_utf8) {
+         bson_free (escaped);
+      }
       return false;
    }
 
@@ -2381,9 +2412,9 @@ _bson_as_json_visit_decimal128 (const bson_iter_t *iter, const char *key, const 
 
    bson_decimal128_to_string (value, decimal128_string);
 
-   bson_string_append (state->str, "{ \"$numberDecimal\" : \"");
-   bson_string_append (state->str, decimal128_string);
-   bson_string_append (state->str, "\" }");
+   bson_string_append (state->str, STR_AND_LEN("{ \"$numberDecimal\" : \""));
+   bson_string_append (state->str, decimal128_string, strlen (decimal128_string));
+   bson_string_append (state->str, STR_AND_LEN("\" }"));
 
    return false;
 }
@@ -2407,16 +2438,16 @@ _bson_as_json_visit_double (const bson_iter_t *iter, const char *key, double v_d
             (state->mode == BSON_JSON_MODE_RELAXED && !(v_double != v_double || v_double * 0 != 0));
 
    if (!legacy) {
-      bson_string_append (state->str, "{ \"$numberDouble\" : \"");
+      bson_string_append (state->str, STR_AND_LEN("{ \"$numberDouble\" : \""));
    }
 
    if (!legacy && v_double != v_double) {
-      bson_string_append (str, "NaN");
+      bson_string_append (str, STR_AND_LEN("NaN"));
    } else if (!legacy && v_double * 0 != 0) {
       if (v_double > 0) {
-         bson_string_append (str, "Infinity");
+         bson_string_append (str, STR_AND_LEN("Infinity"));
       } else {
-         bson_string_append (str, "-Infinity");
+         bson_string_append (str, STR_AND_LEN("-Infinity"));
       }
    } else {
       start_len = str->len;
@@ -2424,12 +2455,12 @@ _bson_as_json_visit_double (const bson_iter_t *iter, const char *key, double v_d
 
       /* ensure trailing ".0" to distinguish "3" from "3.0" */
       if (strspn (&str->str[start_len], "0123456789-") == str->len - start_len) {
-         bson_string_append (str, ".0");
+         bson_string_append (str, STR_AND_LEN(".0"));
       }
    }
 
    if (!legacy) {
-      bson_string_append (state->str, "\" }");
+      bson_string_append (state->str, STR_AND_LEN("\" }"));
    }
 
    return false;
@@ -2444,7 +2475,7 @@ _bson_as_json_visit_undefined (const bson_iter_t *iter, const char *key, void *d
    BSON_UNUSED (iter);
    BSON_UNUSED (key);
 
-   bson_string_append (state->str, "{ \"$undefined\" : true }");
+   bson_string_append (state->str, STR_AND_LEN("{ \"$undefined\" : true }"));
 
    return false;
 }
@@ -2458,7 +2489,7 @@ _bson_as_json_visit_null (const bson_iter_t *iter, const char *key, void *data)
    BSON_UNUSED (iter);
    BSON_UNUSED (key);
 
-   bson_string_append (state->str, "null");
+   bson_string_append (state->str, STR_AND_LEN("null"));
 
    return false;
 }
@@ -2474,9 +2505,9 @@ _bson_as_json_visit_oid (const bson_iter_t *iter, const char *key, const bson_oi
    BSON_UNUSED (key);
 
    bson_oid_to_string (oid, str);
-   bson_string_append (state->str, "{ \"$oid\" : \"");
-   bson_string_append (state->str, str);
-   bson_string_append (state->str, "\" }");
+   bson_string_append (state->str, STR_AND_LEN("{ \"$oid\" : \""));
+   bson_string_append (state->str, str, sizeof(str) - 1); /* oid length is always 24 characters */
+   bson_string_append (state->str, STR_AND_LEN("\" }"));
 
    return false;
 }
@@ -2492,6 +2523,7 @@ _bson_as_json_visit_binary (const bson_iter_t *iter,
 {
    bson_json_state_t *state = data;
    size_t b64_len;
+   int b64_actual_len;
    char *b64;
 
    BSON_UNUSED (iter);
@@ -2499,20 +2531,21 @@ _bson_as_json_visit_binary (const bson_iter_t *iter,
 
    b64_len = mcommon_b64_ntop_calculate_target_size (v_binary_len);
    b64 = bson_malloc0 (b64_len);
-   BSON_ASSERT (mcommon_b64_ntop (v_binary, v_binary_len, b64, b64_len) != -1);
+   b64_actual_len = mcommon_b64_ntop (v_binary, v_binary_len, b64, b64_len);
+   BSON_ASSERT (b64_actual_len != -1);
 
    if (state->mode == BSON_JSON_MODE_CANONICAL || state->mode == BSON_JSON_MODE_RELAXED) {
-      bson_string_append (state->str, "{ \"$binary\" : { \"base64\" : \"");
-      bson_string_append (state->str, b64);
-      bson_string_append (state->str, "\", \"subType\" : \"");
+      bson_string_append (state->str, STR_AND_LEN("{ \"$binary\" : { \"base64\" : \""));
+      bson_string_append (state->str, b64, b64_actual_len);
+      bson_string_append (state->str, STR_AND_LEN("\", \"subType\" : \""));
       bson_string_append_printf (state->str, "%02x", v_subtype);
-      bson_string_append (state->str, "\" } }");
+      bson_string_append (state->str, STR_AND_LEN("\" } }"));
    } else {
-      bson_string_append (state->str, "{ \"$binary\" : \"");
-      bson_string_append (state->str, b64);
-      bson_string_append (state->str, "\", \"$type\" : \"");
+      bson_string_append (state->str, STR_AND_LEN("{ \"$binary\" : \""));
+      bson_string_append (state->str, b64, b64_actual_len);
+      bson_string_append (state->str, STR_AND_LEN("\", \"$type\" : \""));
       bson_string_append_printf (state->str, "%02x", v_subtype);
-      bson_string_append (state->str, "\" }");
+      bson_string_append (state->str, STR_AND_LEN("\" }"));
    }
 
    bson_free (b64);
@@ -2529,7 +2562,11 @@ _bson_as_json_visit_bool (const bson_iter_t *iter, const char *key, bool v_bool,
    BSON_UNUSED (iter);
    BSON_UNUSED (key);
 
-   bson_string_append (state->str, v_bool ? "true" : "false");
+   if (v_bool) {
+      bson_string_append (state->str, STR_AND_LEN("true"));
+   } else {
+      bson_string_append (state->str, STR_AND_LEN("false"));
+   }
 
    return false;
 }
@@ -2544,17 +2581,17 @@ _bson_as_json_visit_date_time (const bson_iter_t *iter, const char *key, int64_t
    BSON_UNUSED (key);
 
    if (state->mode == BSON_JSON_MODE_CANONICAL || (state->mode == BSON_JSON_MODE_RELAXED && msec_since_epoch < 0)) {
-      bson_string_append (state->str, "{ \"$date\" : { \"$numberLong\" : \"");
+      bson_string_append (state->str, STR_AND_LEN("{ \"$date\" : { \"$numberLong\" : \""));
       bson_string_append_printf (state->str, "%" PRId64, msec_since_epoch);
-      bson_string_append (state->str, "\" } }");
+      bson_string_append (state->str, STR_AND_LEN("\" } }"));
    } else if (state->mode == BSON_JSON_MODE_RELAXED) {
-      bson_string_append (state->str, "{ \"$date\" : \"");
+      bson_string_append (state->str, STR_AND_LEN("{ \"$date\" : \""));
       _bson_iso8601_date_format (msec_since_epoch, state->str);
-      bson_string_append (state->str, "\" }");
+      bson_string_append (state->str, STR_AND_LEN("\" }"));
    } else {
-      bson_string_append (state->str, "{ \"$date\" : ");
+      bson_string_append (state->str, STR_AND_LEN("{ \"$date\" : "));
       bson_string_append_printf (state->str, "%" PRId64, msec_since_epoch);
-      bson_string_append (state->str, " }");
+      bson_string_append (state->str, STR_AND_LEN(" }"));
    }
 
    return false;
@@ -2567,30 +2604,33 @@ _bson_as_json_visit_regex (
 {
    bson_json_state_t *state = data;
    char *escaped;
+   uint32_t escaped_len;
 
    BSON_UNUSED (iter);
    BSON_UNUSED (key);
 
-   escaped = bson_utf8_escape_for_json (v_regex, -1);
+   escaped = bson_utf8_escape_for_json (v_regex, -1, &escaped_len);
    if (!escaped) {
       return true;
    }
 
    if (state->mode == BSON_JSON_MODE_CANONICAL || state->mode == BSON_JSON_MODE_RELAXED) {
-      bson_string_append (state->str, "{ \"$regularExpression\" : { \"pattern\" : \"");
-      bson_string_append (state->str, escaped);
-      bson_string_append (state->str, "\", \"options\" : \"");
+      bson_string_append (state->str, STR_AND_LEN("{ \"$regularExpression\" : { \"pattern\" : \""));
+      bson_string_append (state->str, escaped, escaped_len);
+      bson_string_append (state->str, STR_AND_LEN("\", \"options\" : \""));
       _bson_append_regex_options_sorted (state->str, v_options);
-      bson_string_append (state->str, "\" } }");
+      bson_string_append (state->str, STR_AND_LEN("\" } }"));
    } else {
-      bson_string_append (state->str, "{ \"$regex\" : \"");
-      bson_string_append (state->str, escaped);
-      bson_string_append (state->str, "\", \"$options\" : \"");
+      bson_string_append (state->str, STR_AND_LEN("{ \"$regex\" : \""));
+      bson_string_append (state->str, escaped, escaped_len);
+      bson_string_append (state->str, STR_AND_LEN("\", \"$options\" : \""));
       _bson_append_regex_options_sorted (state->str, v_options);
-      bson_string_append (state->str, "\" }");
+      bson_string_append (state->str, STR_AND_LEN("\" }"));
    }
 
-   bson_free (escaped);
+   if (escaped != v_regex) {
+      bson_free (escaped);
+   }
 
    return false;
 }
@@ -2605,11 +2645,11 @@ _bson_as_json_visit_timestamp (
    BSON_UNUSED (iter);
    BSON_UNUSED (key);
 
-   bson_string_append (state->str, "{ \"$timestamp\" : { \"t\" : ");
+   bson_string_append (state->str, STR_AND_LEN("{ \"$timestamp\" : { \"t\" : "));
    bson_string_append_printf (state->str, "%u", v_timestamp);
-   bson_string_append (state->str, ", \"i\" : ");
+   bson_string_append (state->str, STR_AND_LEN(", \"i\" : "));
    bson_string_append_printf (state->str, "%u", v_increment);
-   bson_string_append (state->str, " } }");
+   bson_string_append (state->str, STR_AND_LEN(" } }"));
 
    return false;
 }
@@ -2625,46 +2665,48 @@ _bson_as_json_visit_dbpointer (const bson_iter_t *iter,
 {
    bson_json_state_t *state = data;
    char *escaped;
+   uint32_t escaped_len;
    char str[25];
 
    BSON_UNUSED (iter);
    BSON_UNUSED (key);
-   BSON_UNUSED (v_collection_len);
 
-   escaped = bson_utf8_escape_for_json (v_collection, -1);
+   escaped = bson_utf8_escape_for_json (v_collection, v_collection_len, &escaped_len);
    if (!escaped) {
       return true;
    }
 
    if (state->mode == BSON_JSON_MODE_CANONICAL || state->mode == BSON_JSON_MODE_RELAXED) {
-      bson_string_append (state->str, "{ \"$dbPointer\" : { \"$ref\" : \"");
-      bson_string_append (state->str, escaped);
-      bson_string_append (state->str, "\"");
+      bson_string_append (state->str, STR_AND_LEN("{ \"$dbPointer\" : { \"$ref\" : \""));
+      bson_string_append (state->str, escaped, escaped_len);
+      bson_string_append_c (state->str, '\"');
 
       if (v_oid) {
          bson_oid_to_string (v_oid, str);
-         bson_string_append (state->str, ", \"$id\" : { \"$oid\" : \"");
-         bson_string_append (state->str, str);
-         bson_string_append (state->str, "\" }");
+         bson_string_append (state->str, STR_AND_LEN(", \"$id\" : { \"$oid\" : \""));
+         bson_string_append (state->str, str, sizeof(str) - 1); /* oid length is always 24 characters */
+         bson_string_append (state->str, STR_AND_LEN("\" }"));
       }
 
-      bson_string_append (state->str, " } }");
+      bson_string_append (state->str, STR_AND_LEN(" } }"));
    } else {
-      bson_string_append (state->str, "{ \"$ref\" : \"");
-      bson_string_append (state->str, escaped);
-      bson_string_append (state->str, "\"");
+      bson_string_append (state->str, STR_AND_LEN("{ \"$ref\" : \""));
+      bson_string_append (state->str, escaped, escaped_len);
+      bson_string_append_c (state->str, '\"');
 
       if (v_oid) {
          bson_oid_to_string (v_oid, str);
-         bson_string_append (state->str, ", \"$id\" : \"");
-         bson_string_append (state->str, str);
-         bson_string_append (state->str, "\"");
+         bson_string_append (state->str, STR_AND_LEN(", \"$id\" : \""));
+         bson_string_append (state->str, str, sizeof(str) - 1); /* oid length is always 24 characters */
+         bson_string_append_c (state->str, '\"');
       }
 
-      bson_string_append (state->str, " }");
+      bson_string_append (state->str, STR_AND_LEN(" }"));
    }
 
-   bson_free (escaped);
+   if (escaped != v_collection) {
+      bson_free (escaped);
+   }
 
    return false;
 }
@@ -2678,7 +2720,7 @@ _bson_as_json_visit_minkey (const bson_iter_t *iter, const char *key, void *data
    BSON_UNUSED (iter);
    BSON_UNUSED (key);
 
-   bson_string_append (state->str, "{ \"$minKey\" : 1 }");
+   bson_string_append (state->str, STR_AND_LEN("{ \"$minKey\" : 1 }"));
 
    return false;
 }
@@ -2692,17 +2734,18 @@ _bson_as_json_visit_maxkey (const bson_iter_t *iter, const char *key, void *data
    BSON_UNUSED (iter);
    BSON_UNUSED (key);
 
-   bson_string_append (state->str, "{ \"$maxKey\" : 1 }");
+   bson_string_append (state->str, STR_AND_LEN("{ \"$maxKey\" : 1 }"));
 
    return false;
 }
 
 
 static bool
-_bson_as_json_visit_before (const bson_iter_t *iter, const char *key, void *data)
+_bson_as_json_visit_before (const bson_iter_t *iter, const char *key, uint32_t key_len, void *data)
 {
    bson_json_state_t *state = data;
    char *escaped;
+   uint32_t escaped_len;
 
    BSON_UNUSED (iter);
 
@@ -2711,16 +2754,18 @@ _bson_as_json_visit_before (const bson_iter_t *iter, const char *key, void *data
    }
 
    if (state->count) {
-      bson_string_append (state->str, ", ");
+      bson_string_append (state->str, STR_AND_LEN(", "));
    }
 
    if (state->keys) {
-      escaped = bson_utf8_escape_for_json (key, -1);
+      escaped = bson_utf8_escape_for_json (key, key_len, &escaped_len);
       if (escaped) {
-         bson_string_append (state->str, "\"");
-         bson_string_append (state->str, escaped);
-         bson_string_append (state->str, "\" : ");
-         bson_free (escaped);
+         bson_string_append_c (state->str, '\"');
+         bson_string_append (state->str, escaped, escaped_len);
+         bson_string_append (state->str, STR_AND_LEN("\" : "));
+         if (escaped != key) {
+            bson_free (escaped);
+         }
       } else {
          return true;
       }
@@ -2736,6 +2781,7 @@ static bool
 _bson_as_json_visit_after (const bson_iter_t *iter, const char *key, void *data)
 {
    bson_json_state_t *state = data;
+   uint32_t state_str_len;
 
    BSON_UNUSED (iter);
    BSON_UNUSED (key);
@@ -2744,13 +2790,14 @@ _bson_as_json_visit_after (const bson_iter_t *iter, const char *key, void *data)
       return false;
    }
 
-   if (bson_cmp_greater_equal_us (state->str->len, state->max_len)) {
+   state_str_len = _state_str_len(state);
+   if (bson_cmp_greater_equal_us (state_str_len, state->max_len)) {
       state->max_len_reached = true;
 
-      if (bson_cmp_greater_us (state->str->len, state->max_len)) {
+      if (bson_cmp_greater_us (state_str_len, state->max_len)) {
          BSON_ASSERT (bson_in_range_signed (uint32_t, state->max_len));
          /* Truncate string to maximum length */
-         bson_string_truncate (state->str, (uint32_t) state->max_len);
+         bson_string_truncate (state->str, state->start_pos + (uint32_t)state->max_len);
       }
 
       return true;
@@ -2772,19 +2819,22 @@ _bson_as_json_visit_code (const bson_iter_t *iter, const char *key, size_t v_cod
 {
    bson_json_state_t *state = data;
    char *escaped;
+   uint32_t escaped_len;
 
    BSON_UNUSED (iter);
    BSON_UNUSED (key);
 
-   escaped = bson_utf8_escape_for_json (v_code, v_code_len);
+   escaped = bson_utf8_escape_for_json (v_code, v_code_len, &escaped_len);
    if (!escaped) {
       return true;
    }
 
-   bson_string_append (state->str, "{ \"$code\" : \"");
-   bson_string_append (state->str, escaped);
-   bson_string_append (state->str, "\" }");
-   bson_free (escaped);
+   bson_string_append (state->str, STR_AND_LEN("{ \"$code\" : \""));
+   bson_string_append (state->str, escaped, escaped_len);
+   bson_string_append (state->str, STR_AND_LEN("\" }"));
+   if (escaped != v_code) {
+      bson_free (escaped);
+   }
 
    return false;
 }
@@ -2796,26 +2846,29 @@ _bson_as_json_visit_symbol (
 {
    bson_json_state_t *state = data;
    char *escaped;
+   uint32_t escaped_len;
 
    BSON_UNUSED (iter);
    BSON_UNUSED (key);
 
-   escaped = bson_utf8_escape_for_json (v_symbol, v_symbol_len);
+   escaped = bson_utf8_escape_for_json (v_symbol, v_symbol_len, &escaped_len);
    if (!escaped) {
       return true;
    }
 
    if (state->mode == BSON_JSON_MODE_CANONICAL || state->mode == BSON_JSON_MODE_RELAXED) {
-      bson_string_append (state->str, "{ \"$symbol\" : \"");
-      bson_string_append (state->str, escaped);
-      bson_string_append (state->str, "\" }");
+      bson_string_append (state->str, STR_AND_LEN("{ \"$symbol\" : \""));
+      bson_string_append (state->str, escaped, escaped_len);
+      bson_string_append (state->str, STR_AND_LEN("\" }"));
    } else {
-      bson_string_append (state->str, "\"");
-      bson_string_append (state->str, escaped);
-      bson_string_append (state->str, "\"");
+      bson_string_append_c (state->str, '\"');
+      bson_string_append (state->str, escaped, escaped_len);
+      bson_string_append_c (state->str, '\"');
    }
 
-   bson_free (escaped);
+   if (escaped != v_symbol) {
+      bson_free (escaped);
+   }
 
    return false;
 }
@@ -2827,37 +2880,43 @@ _bson_as_json_visit_codewscope (
 {
    bson_json_state_t *state = data;
    char *code_escaped;
+   uint32_t escaped_len;
    char *scope;
+   size_t scope_len;
    int32_t max_scope_len = BSON_MAX_LEN_UNLIMITED;
+   uint32_t state_str_len;
 
    BSON_UNUSED (iter);
    BSON_UNUSED (key);
 
-   code_escaped = bson_utf8_escape_for_json (v_code, v_code_len);
+   code_escaped = bson_utf8_escape_for_json (v_code, v_code_len, &escaped_len);
    if (!code_escaped) {
       return true;
    }
 
-   bson_string_append (state->str, "{ \"$code\" : \"");
-   bson_string_append (state->str, code_escaped);
-   bson_string_append (state->str, "\", \"$scope\" : ");
+   bson_string_append (state->str, STR_AND_LEN("{ \"$code\" : \""));
+   bson_string_append (state->str, code_escaped, escaped_len);
+   bson_string_append (state->str, STR_AND_LEN("\", \"$scope\" : "));
 
-   bson_free (code_escaped);
+   if (code_escaped != v_code) {
+      bson_free (code_escaped);
+   }
 
    /* Encode scope with the same mode */
    if (state->max_len != BSON_MAX_LEN_UNLIMITED) {
-      BSON_ASSERT (bson_in_range_unsigned (int32_t, state->str->len));
-      max_scope_len = BSON_MAX (0, state->max_len - (int32_t) state->str->len);
+      state_str_len = _state_str_len(state);
+      BSON_ASSERT (bson_in_range_unsigned (int32_t, state_str_len));
+      max_scope_len = BSON_MAX (0, state->max_len - (int32_t) state_str_len);
    }
 
-   scope = _bson_as_json_visit_all (v_scope, NULL, state->mode, max_scope_len, false);
+   scope = _bson_as_json_visit_all (v_scope, &scope_len, state->mode, max_scope_len, false);
 
    if (!scope) {
       return true;
    }
 
-   bson_string_append (state->str, scope);
-   bson_string_append (state->str, " }");
+   bson_string_append (state->str, scope, scope_len);
+   bson_string_append (state->str, STR_AND_LEN(" }"));
 
    bson_free (scope);
 
@@ -2884,33 +2943,36 @@ _bson_as_json_visit_document (const bson_iter_t *iter, const char *key, const bs
    bson_json_state_t *state = data;
    bson_json_state_t child_state = {0, true, state->err_offset};
    bson_iter_t child;
+   uint32_t state_str_len;
 
    BSON_UNUSED (iter);
    BSON_UNUSED (key);
 
    if (state->depth >= BSON_MAX_RECURSION) {
-      bson_string_append (state->str, "{ ... }");
+      bson_string_append (state->str, STR_AND_LEN("{ ... }"));
       return false;
    }
 
    if (bson_iter_init (&child, v_document)) {
-      child_state.str = bson_string_new ("{ ");
+      child_state.start_pos = state->str->len;
+      child_state.str = state->str;
       child_state.depth = state->depth + 1;
       child_state.mode = state->mode;
       child_state.max_len = BSON_MAX_LEN_UNLIMITED;
       if (state->max_len != BSON_MAX_LEN_UNLIMITED) {
-         BSON_ASSERT (bson_in_range_unsigned (int32_t, state->str->len));
-         child_state.max_len = BSON_MAX (0, state->max_len - (int32_t) state->str->len);
+         state_str_len = _state_str_len(state);
+         BSON_ASSERT (bson_in_range_unsigned (int32_t, state_str_len));
+         child_state.max_len = BSON_MAX (0, state->max_len - (int32_t) state_str_len);
       }
 
       child_state.max_len_reached = child_state.max_len == 0;
+      
+      bson_string_append (child_state.str, STR_AND_LEN("{ "));
 
       if (bson_iter_visit_all (&child, &bson_as_json_visitors, &child_state)) {
-         if (child_state.max_len_reached) {
-            bson_string_append (state->str, child_state.str->str);
+         if (!child_state.max_len_reached) {
+            bson_string_truncate (state->str, child_state.start_pos);
          }
-
-         bson_string_free (child_state.str, true);
 
          /* If max_len was reached, we return a success state to ensure that
           * VISIT_AFTER is still called
@@ -2918,9 +2980,7 @@ _bson_as_json_visit_document (const bson_iter_t *iter, const char *key, const bs
          return !child_state.max_len_reached;
       }
 
-      bson_string_append (child_state.str, " }");
-      bson_string_append (state->str, child_state.str->str);
-      bson_string_free (child_state.str, true);
+      bson_string_append (child_state.str, STR_AND_LEN(" }"));
    }
 
    return false;
@@ -2933,33 +2993,36 @@ _bson_as_json_visit_array (const bson_iter_t *iter, const char *key, const bson_
    bson_json_state_t *state = data;
    bson_json_state_t child_state = {0, false, state->err_offset};
    bson_iter_t child;
+   uint32_t state_str_len;
 
    BSON_UNUSED (iter);
    BSON_UNUSED (key);
 
    if (state->depth >= BSON_MAX_RECURSION) {
-      bson_string_append (state->str, "{ ... }");
+      bson_string_append (state->str, STR_AND_LEN("{ ... }"));
       return false;
    }
 
    if (bson_iter_init (&child, v_array)) {
-      child_state.str = bson_string_new ("[ ");
+      child_state.start_pos = state->str->len;
+      child_state.str = state->str;
       child_state.depth = state->depth + 1;
       child_state.mode = state->mode;
       child_state.max_len = BSON_MAX_LEN_UNLIMITED;
       if (state->max_len != BSON_MAX_LEN_UNLIMITED) {
-         BSON_ASSERT (bson_in_range_unsigned (int32_t, state->str->len));
-         child_state.max_len = BSON_MAX (0, state->max_len - (int32_t) state->str->len);
+         state_str_len = _state_str_len(state);
+         BSON_ASSERT (bson_in_range_unsigned (int32_t, state_str_len));
+         child_state.max_len = BSON_MAX (0, state->max_len - (int32_t) state_str_len);
       }
 
       child_state.max_len_reached = child_state.max_len == 0;
 
-      if (bson_iter_visit_all (&child, &bson_as_json_visitors, &child_state)) {
-         if (child_state.max_len_reached) {
-            bson_string_append (state->str, child_state.str->str);
-         }
+      bson_string_append (child_state.str, STR_AND_LEN("[ "));
 
-         bson_string_free (child_state.str, true);
+      if (bson_iter_visit_all (&child, &bson_as_json_visitors, &child_state)) {
+         if (!child_state.max_len_reached) {
+            bson_string_truncate (state->str, child_state.start_pos);
+         }
 
          /* If max_len was reached, we return a success state to ensure that
           * VISIT_AFTER is still called
@@ -2967,9 +3030,7 @@ _bson_as_json_visit_array (const bson_iter_t *iter, const char *key, const bson_
          return !child_state.max_len_reached;
       }
 
-      bson_string_append (child_state.str, " ]");
-      bson_string_append (state->str, child_state.str->str);
-      bson_string_free (child_state.str, true);
+      bson_string_append (child_state.str, STR_AND_LEN(" ]"));
    }
 
    return false;
@@ -3006,6 +3067,7 @@ _bson_as_json_visit_all (
    state.count = 0;
    state.keys = !is_outermost_array;
    state.str = bson_string_new (is_outermost_array ? "[ " : "{ ");
+   state.start_pos = 0;
    state.depth = 0;
    state.err_offset = &err_offset;
    state.mode = mode;
@@ -3025,11 +3087,15 @@ _bson_as_json_visit_all (
 
    /* Append closing space and } separately, in case we hit the max in between.
     */
-   remaining = state.max_len - state.str->len;
+   remaining = state.max_len - _state_str_len(&state);
    if (state.max_len == BSON_MAX_LEN_UNLIMITED || remaining > 1) {
-      bson_string_append (state.str, is_outermost_array ? " ]" : " }");
+      if (is_outermost_array) {
+         bson_string_append (state.str, STR_AND_LEN(" ]"));
+      } else {
+         bson_string_append (state.str, STR_AND_LEN(" }"));
+      }
    } else if (remaining == 1) {
-      bson_string_append (state.str, " ");
+      bson_string_append_c (state.str, ' ');
    }
 
    if (length) {
@@ -3136,8 +3202,10 @@ _bson_iter_validate_corrupt (const bson_iter_t *iter, void *data)
 
 
 static bool
-_bson_iter_validate_before (const bson_iter_t *iter, const char *key, void *data)
+_bson_iter_validate_before (const bson_iter_t *iter, const char *key, uint32_t key_len, void *data)
 {
+   BSON_UNUSED (key_len);
+
    bson_validate_state_t *state = data;
 
    if ((state->flags & BSON_VALIDATE_EMPTY_KEYS)) {

--- a/test/test_bsonjs.py
+++ b/test/test_bsonjs.py
@@ -257,6 +257,11 @@ class TestBsonjs(unittest.TestCase):
         bson_bytes = bsonjs.loads(json_str)
         self.assertEqual(json_str, bsonjs.dumps(bson_bytes + bson_bytes))
 
+    def test_dumps_escaped_and_unicode_characters(self):
+        json_str = '{ "escaped_character_at_the_beginning" : "\\tbeginning", "escaped_character_at_the_end" : "end\\\"", "escaped_character_in_the_middle" : "midd\\\\le", "unicode_character_at_the_beginning" : "\N{CHECK MARK}beginning", "unicode_character_at_the_end" : "end\N{CHECK MARK}", "unicode_character_in_the_middle" : "midd\N{CHECK MARK}le", "no_escaped_or_unicode_characters" : "no escaped or unicode characters" }'
+        bson_bytes = bsonjs.loads(json_str)
+        self.assertEqual(json_str, bsonjs.dumps(bson_bytes))
+
     def test_loads_multiple_json_documents(self):
         json_str = '{ "test" : "me" }'
         self.assertEqual(bsonjs.loads(json_str), bsonjs.loads(json_str + "{}"))


### PR DESCRIPTION
# Overview

Improve the runtime performance of the `bsonjs.dumps` API.

Below are the results from `benchmark.py`, executed before and after my changes. `bsonjs` was compiled with GCC 14.2.0 on SLES 15 and run on Python 3.13.2.

Before my changes:
```
Timing: bsonjs.dumps(b)
10000 loops, best of 3: 0.05099046230316162
Timing: json_util.dumps(bson.decode(b))
10000 loops, best of 3: 0.38455578312277794
bsonjs is 7.54x faster than json_util

Timing: bsonjs.loads(j)
10000 loops, best of 3: 0.05889510316774249
Timing: bson.encode(json_util.loads(j))
10000 loops, best of 3: 0.41942713782191277
bsonjs is 7.12x faster than json_util
```

After my changes:
```
Timing: bsonjs.dumps(b)
10000 loops, best of 3: 0.024287620093673468
Timing: json_util.dumps(bson.decode(b))
10000 loops, best of 3: 0.39230786077678204
bsonjs is 16.15x faster than json_util

Timing: bsonjs.loads(j)
10000 loops, best of 3: 0.057051923125982285
Timing: bson.encode(json_util.loads(j))
10000 loops, best of 3: 0.41939733177423477
bsonjs is 7.35x faster than json_util
```

My internal tool processes BSON files, some of which are extremely large and are probably not representative of the BSON data that most users work with.
As a result, the performance improvements described below may be most relevant to workloads with similar characteristics.
For example, I have a BSON file with a size of 791,038,613 bytes, containing:
* 7,876,079 dictionaries
* 18,837 lists
* 31,568,552 primitives

It is important to note that these BSON files rarely contain escaped or Unicode characters.

I used Copilot to identify potential areas for runtime optimization. Some of the suggested improvements provided measurable gains in this use case.
I would appreciate it if you could review my changes and, if appropriate, provide feedback, commit them, and include them in a future release.

The overall runtime of my test case was reduced from 19.50 seconds to 4.91 seconds (a 74.8% reduction).
The table below shows the runtime reduction contributed by each change:

| Index | Change                                         | Runtime Improvement (seconds) |
| ----- | ---------------------------------------------- | ----------------------------- |
| 1     | bson_utf8_escape_for_json optimization         | 9.02                          |
| 2     | Nested string copy elimination in BSON visitor | 3.86                          |
| 3     | bson_string_append_printf optimization         | 0.47                          |
| 4     | bson_utf8_validate optimization                | 0.54                          |
| 5     | Eliminate Redundant strlen Calls               | 0.67                          |


# Testing

I ran the Python test suite and added a unit test for the "`bson_utf8_escape_for_json` optimization".
In addition, to validate the "Nested string copy elimination in BSON visitor" changes, I locally enabled the "BSON max len limited" configuration (this change was used only for testing and is not included in the commit). I tested all possible values using sample data containing BSON objects and obtained identical results both with and without my changes.
I also tested the complete set of changes on several BSON files and obtained identical results with and without the optimizations.


# Code changes

## 1. `bson_utf8_escape_for_json` optimization
Problem:
The `bson_utf8_escape_for_json` function is called for every string value and key. It always creates a new `bson_string_t` and processes escape and Unicode characters even when the string does not contain any.
This leads to unnecessary memory allocations and copying.

Fix:
Update the function to:
* Return the original string as is if it contains no escape or Unicode characters (calling function should not free it)
* Allocate and return a modified string only when needed (calling function should free it)

Files changed:
* `bsonjs/bson/bson-string.c`: `bson_string_new_n, bson_string_new`
* `bsonjs/bson/bson-string.h`: `bson_string_new_n`
* `bsonjs/bson/bson-utf8.c`
* `bsonjs/bson/bson.c`: `_bson_as_json_visit_utf8`, `_bson_as_json_visit_regex`, `_bson_as_json_visit_dbpointer`, `_bson_as_json_visit_before`, `_bson_as_json_visit_code`, `_bson_as_json_visit_symbol`, `_bson_as_json_visit_codewscope`
* `test/test_bsonjs.py`: `test_dumps_escaped_and_unicode_characters`


## 2. Nested string copy elimination in BSON visitor
Problem:
For each nested document or array:
* A separate `bson_string_t` is allocated
* The entire child JSON is built in that buffer
* The result is copied into the parent buffer
* The child buffer is then freed
This causes excessive allocations and copying.

Fix:
Use a single shared `bson_string_t` buffer across all nesting levels.

Files changed:
* `bsonjs/bson/bson.c`: `_state_str_len`, `bson_json_state_t`, `_bson_as_json_visit_after`, `_bson_as_json_visit_codewscope`, `_bson_as_json_visit_document`, `_bson_as_json_visit_array`, `_bson_as_json_visit_all`


## 3. `bson_string_append_printf` optimization
Problem:
Each call to `bson_string_append_printf`:
* Allocates a temporary buffer
* Uses `vsnprintf` into it
* Appends to the main string
* Frees the temporary buffer
This results in frequent heap allocations.

Fix:
* Use a stack-allocated buffer for `vsnprintf`
* Append directly when the buffer is sufficient
* Fall back to heap allocation only when necessary

Files changed:
* `bsonjs/bson/bson-string.c`: `bson_string_append_printf`, `bson_strdupv_printf`, `bson_strdup_printf`
* `bsonjs/bson/bson-string.h`: `bson_strdupv_printf`


## 4. `bson_utf8_validate` optimization
Problem:
* An inefficient loop was used to check whether a null character exists before the end of a string.

Fix:
* Replaced the loop with `memchr` for more efficient detection.

Files changed:
* `bsonjs/bson/bson-utf8.c`: `bson_utf8_validate`


## 5. Eliminate Redundant `strlen` Calls
Problem:
* Many redundant calls to `strlen` are made even though the string length is already known.

Fix:
* Reuse previously computed string lengths instead of recalculating them with `strlen`.

Files changed:
* `bsonjs/bson/bson-iso8601.c`: `_bson_iso8601_date_format`
* `bsonjs/bson/bson-iter.c`: `bson_iter_visit_all`
* `bsonjs/bson/bson-string.c`: `bson_string_append`, `bson_string_append_c`, `bson_string_append_unichar`, `bson_string_append_printf`, `bson_strdupv_printf`, `bson_strdup_printf`
* `bsonjs/bson/bson-string.h`: `STR_AND_LEN`, `bson_string_append`, `bson_string_append_printf`
* `bsonjs/bson/bson-utf8.c`: `bson_utf8_escape_for_json`
* `bsonjs/bson/bson-utf8.h`: `bson_utf8_escape_for_json`
* `bsonjs/bson/bson.c`: `_bson_as_json_visit_utf8`, `_bson_as_json_visit_decimal128`, `_bson_as_json_visit_double`, `_bson_as_json_visit_undefined`, `_bson_as_json_visit_null`, `_bson_as_json_visit_oid`, `_bson_as_json_visit_binary`, `_bson_as_json_visit_bool`, `_bson_as_json_visit_date_time`, `_bson_as_json_visit_regex`, `_bson_as_json_visit_timestamp`, `_bson_as_json_visit_dbpointer`, `_bson_as_json_visit_minkey`, `_bson_as_json_visit_maxkey`, `_bson_as_json_visit_before`, `_bson_as_json_visit_code`, `_bson_as_json_visit_symbol`, `_bson_as_json_visit_codewscope`, `_bson_as_json_visit_document`, `_bson_as_json_visit_array`, `_bson_as_json_visit_all`, `_bson_iter_validate_before`
