### PR TITLE
INTPYTHON-1091 Derive bsonjs.__version__ from pyproject.toml

### DIFF
--- a/bsonjs/bsonjs.c
+++ b/bsonjs/bsonjs.c
@@ -264,7 +264,7 @@ PyInit_bsonjs(void)
 
     if (PyModule_AddObject(module,
                            "__version__",
-                           PyUnicode_FromString("0.3.0"))) {
+                           PyUnicode_FromString(BSONJS_VERSION))) {
         Py_DECREF(module);
         INITERROR;
     }

--- a/setup.py
+++ b/setup.py
@@ -13,9 +13,26 @@
 # limitations under the License.
 
 import glob
+import re
 import sys
+from pathlib import Path
 
 from setuptools import setup, Extension
+
+
+def _read_version():
+    """Read the package version from pyproject.toml.
+
+    Keeps bsonjs.__version__ from drifting out of sync with the
+    package version, since this extension has no pure-Python __init__.py
+    to derive it from package metadata at import time instead.
+    """
+    text = (Path(__file__).parent / "pyproject.toml").read_text()
+    match = re.search(r'(?m)^version\s*=\s*"([^"]+)"', text)
+    if not match:
+        raise RuntimeError("Could not find version in pyproject.toml")
+    return match.group(1)
+
 
 libraries = []
 if sys.platform == "win32":
@@ -35,7 +52,8 @@ setup(
                           "bsonjs/common"],
             py_limited_api=True,
             define_macros=[("BSON_COMPILATION", 1),
-                           ("Py_LIMITED_API", "0x03090000")],
+                           ("Py_LIMITED_API", "0x03090000"),
+                           ("BSONJS_VERSION", '"%s"' % _read_version())],
             libraries=libraries
         )
     ],


### PR DESCRIPTION
INTPYTHON-1091

## Summary
`bsonjs.__version__` was hardcoded as `"0.3.0"` in `bsonjs.c` and had silently drifted from `pyproject.toml`'s version for years — the package is now at `0.8.0.dev0`.

## Motivation
Found while reviewing [PYTHON-6050](https://jira.mongodb.org/browse/PYTHON-6050) (the libbson 2.5.0 bump). `bsonjs` is a single-file C extension with no pure-Python `__init__.py`, so it can't derive its version from installed package metadata at import time the way a wrapped package could — the version has to be baked in at build time instead.

## Changes
- `setup.py` now reads the version out of `pyproject.toml` and passes it to the compiler as the `BSONJS_VERSION` macro.
- `bsonjs.c` uses `BSONJS_VERSION` instead of the hardcoded `"0.3.0"` literal when setting `__version__`.

## Testing
- `python setup.py build_ext --inplace` succeeds.
- `python -c "import bsonjs; print(bsonjs.__version__)"` prints `0.8.0.dev0`.
- `pytest test/` — 23 passed.