### PR TITLE
INTPYTHON-1092 Fix size_t/Py_ssize_t mismatch in bsonjs.c's Py_BuildValue call

### DIFF
--- a/bsonjs/bsonjs.c
+++ b/bsonjs/bsonjs.c
@@ -82,6 +82,11 @@ _dumps(PyObject *bson, int mode)
         return NULL;
     }
 
+    if (json_len > (size_t)PY_SSIZE_T_MAX) {
+        bson_free((void *)json);
+        PyErr_SetString(PyExc_OverflowError, "Extended JSON output is too large");
+        return NULL;
+    }
     rv = Py_BuildValue("s#", json, (Py_ssize_t)json_len);
     bson_free((void *)json);
     return rv;

--- a/bsonjs/bsonjs.c
+++ b/bsonjs/bsonjs.c
@@ -82,7 +82,7 @@ _dumps(PyObject *bson, int mode)
         return NULL;
     }
 
-    rv = Py_BuildValue("s#", json, json_len);
+    rv = Py_BuildValue("s#", json, (Py_ssize_t)json_len);
     bson_free((void *)json);
     return rv;
 }


### PR DESCRIPTION
INTPYTHON-1092

## Summary
`_dumps()` in `bsonjs.c` passed a `size_t` length to `Py_BuildValue("s#", ...)`, which expects a `Py_ssize_t` under `PY_SSIZE_T_CLEAN` (defined in `bsonjs.h`). The two types happen to be the same width on today's common 64-bit platforms, so this worked in practice, but it's reading the wrong type out of the varargs list.

## Motivation
Found while reviewing [PYTHON-6050](https://jira.mongodb.org/browse/PYTHON-6050) (the libbson 2.5.0 bump). `json_len` is `size_t` because it comes from `bson_str_to_json`/libbson's `bson_as_*_extended_json` output-length parameters; `load()`/`loads()` on the read side already use `Py_ssize_t` correctly, so `_dumps()` was the only mismatched call site.

## Changes
- Cast `json_len` to `Py_ssize_t` at the `Py_BuildValue("s#", ...)` call site in `_dumps()`.

## Testing
- `python setup.py build_ext --inplace` succeeds.
- `pytest test/` — 23 passed.